### PR TITLE
Fixes incorrect environment variable for GraphQL password

### DIFF
--- a/run_server.sh
+++ b/run_server.sh
@@ -1,6 +1,6 @@
 export GRAPHQL_URL="http://localhost:4000/graphql"
 export GRAPHQL_USR="username1"
-export GRAPQHL_PWD="password1"
+export GRAPHQL_PWD="password1"
 export MCP_PORT=3001
 export NODE_TLS_REJECT_UNAUTHORIZED=0
 node index.js


### PR DESCRIPTION
This PR corrects a typo in the run_server.sh script:
GRAPQHL_PWD was misspelled, preventing the MCP server from logging into the WinCC Unified GraphQL API.
	•	Updated: GRAPQHL_PWD ➝ GRAPHQL_PWD
	•	This resolves login error Code: 101 - Incorrect credentials

Tested and confirmed working with live MCP server and valid credentials.